### PR TITLE
Add search

### DIFF
--- a/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/controller/FilmController.java
@@ -70,5 +70,10 @@ public class FilmController {
     public Collection<Film> findCommonFilms(@RequestParam Integer userId, Integer friendId) {
         return filmService.findCommonFilms(userId, friendId);
     }
+
+    @GetMapping("/search")
+    public Collection<Film> findFilmsBy(@RequestParam String query, @RequestParam String by) {
+        return filmService.getFilmsBy(query, by);
+    }
 }
 

--- a/src/main/java/ru/yandex/practicum/filmorate/service/film/FilmService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/film/FilmService.java
@@ -28,4 +28,6 @@ public interface FilmService {
     Collection<Film> getPopular(Integer count, Integer genreId, String year);
 
     Collection<Film> findCommonFilms(Integer userId, Integer friendId);
+
+    Collection<Film> getFilmsBy(String query, String by);
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/service/film/FilmServiceImpl.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/film/FilmServiceImpl.java
@@ -3,6 +3,7 @@ package ru.yandex.practicum.filmorate.service.film;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import ru.yandex.practicum.filmorate.exception.IncorrectParameterException;
 import ru.yandex.practicum.filmorate.model.Director;
 import ru.yandex.practicum.filmorate.model.Film;
 import ru.yandex.practicum.filmorate.storage.director.DirectorStorage;
@@ -106,5 +107,20 @@ public class FilmServiceImpl implements FilmService {
     @Override
     public Collection<Film> findCommonFilms(Integer userId, Integer friendId) {
         return filmStorage.findCommonFilms(userId, friendId);
+    }
+
+    @Override
+    public Collection<Film> getFilmsBy(String query, String by) {
+        switch (by.toLowerCase().strip()) {
+            case "director":
+                return filmStorage.findFilmsByDirector(query);
+            case "title":
+                return filmStorage.findFilmsByTitle(query);
+            case "title,director":
+            case "director,title":
+                return filmStorage.findFilmsByDirectorAndTitle(query);
+            default:
+                throw new IncorrectParameterException("Incorrect params. query:" + query + " by:" + by);
+        }
     }
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmStorage.java
@@ -38,4 +38,10 @@ public interface FilmStorage {
     List<Film> getByDirectorSortByYear(int id);
 
     Collection<Film> getUserRecommendations(Integer userId);
+
+    Collection<Film> findFilmsByDirector(String query);
+
+    Collection<Film> findFilmsByTitle(String query);
+
+    Collection<Film> findFilmsByDirectorAndTitle(String query);
 }

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/dao/FilmDbStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/dao/FilmDbStorage.java
@@ -213,6 +213,49 @@ public class FilmDbStorage implements FilmStorage {
     }
 
     @Override
+    public Collection<Film> findFilmsByDirector(String query) {
+        String lowerQuery = "%" + query.toLowerCase() + "%";
+        String sql = "SELECT *, COUNT(UF.FILM_ID) AS LIKES " +
+                "FROM FILMS F " +
+                "LEFT OUTER JOIN RATING AS R ON R.RATING_ID = F.RATING " +
+                "LEFT OUTER JOIN FILM_DIRECTOR AS FD ON FD.FILM_ID = F.FILM_ID " +
+                "LEFT OUTER JOIN DIRECTOR AS D ON D.DIRECTOR_ID = FD.DIRECTOR_ID " +
+                "LEFT JOIN USER_FILM AS UF ON UF.FILM_ID = F.FILM_ID " +
+                "WHERE LOWER(D.NAME) like ? " +
+                "GROUP BY F.FILM_ID " +
+                "ORDER BY LIKES DESC";
+        return jdbcTemplate.query(sql, (rs, rowNum) -> makeFilm(rs), lowerQuery);
+    }
+
+    @Override
+    public Collection<Film> findFilmsByTitle(String query) {
+        String lowerQuery = "%" + query.toLowerCase() + "%";
+        String sql = "SELECT *, COUNT(UF.FILM_ID) AS LIKES " +
+                "FROM FILMS F " +
+                "LEFT OUTER JOIN RATING AS R ON R.RATING_ID = F.RATING " +
+                "LEFT JOIN USER_FILM AS UF ON UF.FILM_ID = F.FILM_ID " +
+                "WHERE LOWER(TITLE) LIKE ? " +
+                "GROUP BY F.FILM_ID " +
+                "ORDER BY LIKES DESC";
+        return jdbcTemplate.query(sql, (rs, rowNum) -> makeFilm(rs), lowerQuery);
+    }
+
+    @Override
+    public Collection<Film> findFilmsByDirectorAndTitle(String query) {
+        String lowerQuery = "%" + query.toLowerCase() + "%";
+        String sql = "SELECT *, COUNT(UF.FILM_ID) AS LIKES " +
+                "FROM FILMS F " +
+                "LEFT OUTER JOIN RATING AS R ON R.RATING_ID = F.RATING " +
+                "LEFT OUTER JOIN FILM_DIRECTOR AS FD ON FD.FILM_ID = F.FILM_ID " +
+                "LEFT OUTER JOIN DIRECTOR AS D ON D.DIRECTOR_ID = FD.DIRECTOR_ID " +
+                "LEFT JOIN USER_FILM AS UF ON UF.FILM_ID = F.FILM_ID " +
+                "WHERE LOWER(TITLE) like ? OR LOWER(D.NAME) like ?" +
+                "GROUP BY F.FILM_ID " +
+                "ORDER BY LIKES DESC";
+        return jdbcTemplate.query(sql, (rs, rowNum) -> makeFilm(rs), lowerQuery, lowerQuery);
+    }
+
+    @Override
     public void checkFilmExist(Integer id) {
         String sqlQuery = "SELECT COUNT(*) FROM FILMS WHERE FILM_ID=? ";
         Optional.ofNullable(jdbcTemplate.queryForObject(sqlQuery, Integer.class, id))

--- a/src/test/java/ru/yandex/practicum/filmorate/storage/film/dao/FilmDbStorageTest.java
+++ b/src/test/java/ru/yandex/practicum/filmorate/storage/film/dao/FilmDbStorageTest.java
@@ -6,10 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
-import ru.yandex.practicum.filmorate.model.Film;
-import ru.yandex.practicum.filmorate.model.Genre;
-import ru.yandex.practicum.filmorate.model.Mpa;
-import ru.yandex.practicum.filmorate.model.User;
+import ru.yandex.practicum.filmorate.model.*;
+import ru.yandex.practicum.filmorate.storage.director.DirectorStorage;
 import ru.yandex.practicum.filmorate.storage.film.FilmStorage;
 import ru.yandex.practicum.filmorate.storage.user.UserStorage;
 
@@ -30,6 +28,7 @@ class FilmDbStorageTest {
 
     private final FilmStorage filmDbStorage;
     private final UserStorage userDbStorage;
+    private final DirectorStorage directorDbStorage;
 
     @Test
     public void addFilmTest() {
@@ -310,7 +309,7 @@ class FilmDbStorageTest {
         Collection<Film> recommendedFilmsForUser1 = filmDbStorage.getUserRecommendations(user_1.getId());
 
         assertFalse(recommendedFilmsForUser1.isEmpty());
-        assertTrue(recommendedFilmsForUser1.containsAll(List.of(film_3)));
+        assertTrue(recommendedFilmsForUser1.contains(film_3));
         assertEquals(1, recommendedFilmsForUser1.size());
     }
 
@@ -366,6 +365,120 @@ class FilmDbStorageTest {
         assertFalse(commonFilms.isEmpty());
         assertTrue(commonFilms.containsAll(List.of(film_1, film_3)));
         assertEquals(2, commonFilms.size());
+    }
+
+    @Test
+    void searchFilmsAnywayByTitleReturnFilms() {
+        // given
+        Film film = filmDbStorage.addFilm(createDefaultFilm());
+
+        // when
+        Collection<Film> findFilms = filmDbStorage.findFilmsByDirectorAndTitle("EsTfI");
+
+        // then
+        assertThat(findFilms)
+                .isNotNull()
+                .usingRecursiveComparison()
+                .isEqualTo(List.of(film));
+    }
+
+    @Test
+    void searchFilmsAnywayByDirectorReturnFilms() {
+        // given
+        Film film = createDefaultFilm();
+        Director addedDirector = directorDbStorage.createDirector(new Director(1, "Director"));
+        film.setDirectors(List.of(addedDirector));
+        Film addedFilm = filmDbStorage.addFilm(film);
+
+        // when
+        Collection<Film> findFilms = filmDbStorage.findFilmsByDirectorAndTitle("IrEc");
+
+        // then
+        assertThat(findFilms)
+                .isNotNull()
+                .usingRecursiveComparison()
+                .isEqualTo(List.of(addedFilm));
+    }
+
+    @Test
+    void searchFilmsAnywayReturnEmpty() {
+        // given
+        filmDbStorage.addFilm(createDefaultFilm());
+
+        // when
+        Collection<Film> findFilms = filmDbStorage.findFilmsByDirectorAndTitle("Films");
+
+        // then
+        assertThat(findFilms)
+                .isNotNull()
+                .usingRecursiveComparison()
+                .isEqualTo(Collections.EMPTY_LIST);
+    }
+
+    @Test
+    void searchFilmsByTitleReturnFilms() {
+        // given
+        Film film = filmDbStorage.addFilm(createDefaultFilm());
+
+        // when
+        Collection<Film> findFilms = filmDbStorage.findFilmsByTitle("EsTfI");
+
+        // then
+        assertThat(findFilms)
+                .isNotNull()
+                .usingRecursiveComparison()
+                .isEqualTo(List.of(film));
+    }
+
+    @Test
+    void searchFilmsByTitleReturnEmpty() {
+        // given
+        filmDbStorage.addFilm(createDefaultFilm());
+
+        // when
+        Collection<Film> findFilms = filmDbStorage.findFilmsByTitle("Films");
+
+        // then
+        assertThat(findFilms)
+                .isNotNull()
+                .usingRecursiveComparison()
+                .isEqualTo(Collections.EMPTY_LIST);
+    }
+
+    @Test
+    void searchFilmsByDirectorReturnFilms() {
+        // given
+        Film film = createDefaultFilm();
+        Director addedDirector = directorDbStorage.createDirector(new Director(1, "Director"));
+        film.setDirectors(List.of(addedDirector));
+        Film addedFilm = filmDbStorage.addFilm(film);
+
+        // when
+        Collection<Film> findFilms = filmDbStorage.findFilmsByDirector("IrEc");
+
+        // then
+        assertThat(findFilms)
+                .isNotNull()
+                .usingRecursiveComparison()
+                .isEqualTo(List.of(addedFilm));
+    }
+
+    @Test
+    void searchFilmsByDirectorReturnEmpty() {
+        // given
+        Film film = createDefaultFilm();
+        Director addedDirector = directorDbStorage.createDirector(new Director(1, "Director"));
+        film.setDirectors(List.of(addedDirector));
+        filmDbStorage.addFilm(film);
+
+        // when
+        Collection<Film> findFilms = filmDbStorage.findFilmsByDirectorAndTitle("direct0r");
+
+        // then
+        assertThat(findFilms)
+                .isNotNull()
+                .usingRecursiveComparison()
+                .isEqualTo(Collections.EMPTY_LIST);
     }
 
     private Film createDefaultFilm() {


### PR DESCRIPTION
Реализован поиск по названию фильмов и по режиссёру.

Алгоритм умеет искать по подстроке. Например, при вводе «крад» в поиске возвращаются следующие фильмы: «Крадущийся тигр, затаившийся дракон», «Крадущийся в ночи» и другие.

## API
`GET /fimls/search`

Возвращает список фильмов, отсортированных по популярности.

### Параметры строки запроса

`query` — текст для поиска

`by` — может принимать значения director (поиск по режиссёру), title (поиск по названию), либо оба значения через запятую при поиске одновременно и по режиссеру и по названию.

### Пример

`GET /films/search?query=крад&by=director,title`